### PR TITLE
Update build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ repositories {
 }
 
 dependencies {
-    compile "commons-collections:commons-collections:[3.2,4.0)"
+    compile "org.apache.commons:commons-collections4:4.0"
     testCompile "junit:junit:[4,5)"
     compile "org.java-websocket:Java-WebSocket:1.3.0"
     compile "com.google.code.gson:gson:2.3.1"


### PR DESCRIPTION
commons-collections:commons-collections 3.x has from the 4.0 release been moved to org.apache.commons:commons-collections4.
Replaced dependency to old 3.x version and added version 4.0
compile "org.apache.commons:commons-collections4:4.0"
I am unable to perform gradle build due to sonatype username/password required when running gradle compile.
Either depend on 3.2 only or upgrade to 4.0 and change the package.