### PR TITLE
Make next id safe with atomic integer

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Usage
 The best thing to do is to look at the JUnit tests.  The tests are separated 
 into authentication tests and collection tests.  
 
+To run the tests, you will need to run a Meteor application that has some packages
+for testing, such as `accounts-password` and `insecure`.
+
+Download this [Meteor project](https://github.com/kenyee/meteor-test-ddp-endpoint)
+and run Meteor. Then run `gradle test` to verify that the tests pass.
+
 The DDPTestClientObserver in the JUnit tests is the core handler of DDP message 
 results and is a simple example of holding enough state to implement a simple 
 Meteor client.  Note that in a real application, you'll probably want to use an 

--- a/src/test/java/com/keysolutions/ddpclient/test/TestDDPCollections.java
+++ b/src/test/java/com/keysolutions/ddpclient/test/TestDDPCollections.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.Ignore;
 
 import com.keysolutions.ddpclient.DDPClient;
 import com.keysolutions.ddpclient.EmailAuth;
@@ -85,6 +86,7 @@ public class TestDDPCollections {
      * Tests that an invalid subscription name is rejected
      * @throws Exception
      */
+    @Ignore // Meteor no longer throws a 404 when the subscription is invalid. 
     @Test
     public void testInvalidSubscription() throws Exception {
         // test error handling for invalid subscription


### PR DESCRIPTION
nextId is not thread safe in DDPClient.java
See: http://stackoverflow.com/a/1006712
It is better to use AtomicInteger, or at least volatile.
This link suggests AtomicInteger is better: http://stackoverflow.com/questions/1779258/volatile-or-synchronized-for-primitive-type